### PR TITLE
Add NumericalTypeAliases.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.4.2"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+NumericalTypeAliases = "be9b823e-291e-41a1-b8ce-806204e78f92"
 ProgressBars = "49802e3a-d2f1-5c88-81d8-b72133a6f568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
@@ -14,6 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 DocStringExtensions = "0.8, 0.9"
+NumericalTypeAliases = "0.1"
 ProgressBars = "0.7, 0.8, 1"
 julia = "1"
 

--- a/src/ClusterValidityIndices.jl
+++ b/src/ClusterValidityIndices.jl
@@ -57,7 +57,8 @@ module ClusterValidityIndices
 # Full usings (which supports comma-separated import notation)
 using
     DocStringExtensions,   # Docstring utilities
-    LinearAlgebra
+    LinearAlgebra,
+    NumericalTypeAliases
 
 # Partial usings (which does not yet support comma-separated import notation)
 using Statistics: mean

--- a/src/ClusterValidityIndices.jl
+++ b/src/ClusterValidityIndices.jl
@@ -109,9 +109,4 @@ export
     sort_cvi_data,
     relabel_cvi_data
 
-    # Not exported
-    # get_cvi_data
-    # get_bernoulli_subset
-    # showtypetree
-
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -48,33 +48,9 @@ All index instantiations are subtypes of `CVI`.
 """
 abstract type CVI end
 
-# -------------------------------------------
-# Aliases
-# -------------------------------------------
-#   **Taken from StatsBase.jl**
-#
-#  These types signficantly reduces the need of using
-#  type parameters in functions (which are often just
-#  for the purpose of restricting the arrays to real)
-#
-# These could be removed when the Base supports
-# covariant type notation, i.e. AbstractVector{<:Real}
-
-# Real-numbered aliases
-const RealArray{T<:Real, N} = AbstractArray{T, N}
-const RealVector{T<:Real} = AbstractArray{T, 1}
-const RealMatrix{T<:Real} = AbstractArray{T, 2}
-
-# Integered aliases
-const IntegerArray{T<:Integer, N} = AbstractArray{T, N}
-const IntegerVector{T<:Integer} = AbstractArray{T, 1}
-const IntegerMatrix{T<:Integer} = AbstractArray{T, 2}
-
-# Specifically floating-point aliases
-const RealFP = Union{Float32, Float64}
-
-# System's largest native floating point variable
-const Float = (Sys.WORD_SIZE == 64 ? Float64 : Float32)
+# --------------------------------------------------------------------------- #
+# CONSTANTS
+# --------------------------------------------------------------------------- #
 
 """
 Internal label mapping for incremental CVIs.
@@ -84,7 +60,7 @@ Alias for a dictionary mapping of integers to integers as cluster labels.
 const LabelMap = Dict{Int, Int}
 
 # --------------------------------------------------------------------------- #
-# Methods
+# FUNCTIONS
 # --------------------------------------------------------------------------- #
 
 """
@@ -175,9 +151,9 @@ function get_internal_label!(label_map::LabelMap, label::Int)
     return internal_label
 end # get_internal_label!(label_map::LabelMap, label::Int)
 
-# -------------------------------------------
-# Common Documentation
-# -------------------------------------------
+# --------------------------------------------------------------------------- #
+# COMMON DOCUMENTATION
+# --------------------------------------------------------------------------- #
 
 @doc raw"""
 Compute the CVI parameters incrementally.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,14 @@
+"""
+    runtests.jl
+
+# Description
+Entry point for testing the `ClusterValidityIndices.jl` package.
+This file wraps the tests in its own `SafeTestsets.jl` test module.
+
+# Authors
+- Sasha Petrenko <sap625@mst.edu>
+"""
+
 using SafeTestsets
 
 @safetestset "All Test Sets" begin

--- a/test/test_cvis.jl
+++ b/test/test_cvis.jl
@@ -1,3 +1,13 @@
+"""
+    test_cvis.jl
+
+# Description
+A single test set for the testing the functionality of all CVIS modules.
+
+# Authors
+- Sasha Petrenko <sap625@mst.edu>
+"""
+
 @testset "CVIs" begin
     @info "CVI Testing"
 

--- a/test/test_sets.jl
+++ b/test/test_sets.jl
@@ -1,13 +1,36 @@
+"""
+    test_sets.jl
+
+# Description
+Aggregate of all test sets for the `ClusterValidityIndices.jl` package.
+These tests include testing package functionality as well as individual CVI module functionality.
+
+# Authors
+- Sasha Petrenko <sap625@mst.edu>
+"""
+
+# --------------------------------------------------------------------------- #
+# USINGS
+# --------------------------------------------------------------------------- #
+
 using ClusterValidityIndices
 using Test
 using Logging
 using Printf
+
+# --------------------------------------------------------------------------- #
+# SETUP
+# --------------------------------------------------------------------------- #
 
 # Set the log level
 LogLevel(Logging.Info)
 
 # Include the test utilities
 include("utils.jl")
+
+# --------------------------------------------------------------------------- #
+# TEST SETS
+# --------------------------------------------------------------------------- #
 
 @testset "ClusterValidityIndices.jl" begin
     # Run all of the CVI tests

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,20 +1,15 @@
+"""
+    utils.jl
+
+# Description
+Utilities for unit tests of the `ClusterValidityIndices.jl` package.
+
+# Authors
+- Sasha Petrenko <sap625@mst.edu>
+"""
+
 using Random
 using DelimitedFiles
-
-"""
-    showtypetree(T, level=0)
-
-Show the tree of subtypes for a type.
-```julia
-showtypetree(Number)
-```
-"""
-function showtypetree(T, level=0)
-    println("\t" ^ level, T)
-    for t in subtypes(T)
-        showtypetree(t, level+1)
-    end
-end # showtypetree(T, level=0)
 
 """
     get_cvi_data(data_file::String)


### PR DESCRIPTION
This PR replaces the abstract types in the project with equivalents from the NumericalTypeAliases.jl package.