### PR TITLE
Unit tests cleanup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 NumericalTypeAliases = "be9b823e-291e-41a1-b8ce-806204e78f92"
 ProgressBars = "49802e3a-d2f1-5c88-81d8-b72133a6f568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ This project has implementations of the following CVIs in both batch and increme
 - **WB**: WB-index
 - **XB**: Xie-Beni
 
+The exported constant `CVI_MODULES` also contains a list of these CVIs for convenient iteration.
+
 ## Usage
 
 The usage of these CVIs requires an understanding of:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,7 +11,6 @@ MLDataUtils = "cc2ba9b6-d476-5e6d-8eaf-a92d5412d41d"
 MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 MLDatasets = "0.7"

--- a/docs/src/man/guide.md
+++ b/docs/src/man/guide.md
@@ -53,6 +53,22 @@ or in batch with `get_cvi`
 criterion_value = get_cvi(data, labels)
 ```
 
+## [Implemented CVIs](@id implemented-cvis)
+
+The `ClusterValidityIndices.jl` package has the following CVIs implemented:
+
+- **CH**: Calinski-Harabasz
+- **cSIL**: Centroid-based Silhouette
+- **DB**: Davies-Bouldin
+- **GD43**: Generalized Dunn's Index 43
+- **GD53**: Generalized Dunn's Index 53
+- **PS**: Partition Separation
+- **rCIP**: (Renyi's) representative Cross Information Potential
+- **WB**: WB-index
+- **XB**: Xie-Beni
+
+The exported constant `CVI_MODULES` also contains a list of these CVIs for convenient iteration.
+
 ## [Usage](@id usage)
 
 The usage of these CVIs requires an understanding of:

--- a/src/CVI/CVI.jl
+++ b/src/CVI/CVI.jl
@@ -6,12 +6,25 @@ Description:
 """
 
 # include("CONN.jl")
-include("XB.jl")
-include("DB.jl")
-include("PS.jl")
 include("CH.jl")
 include("cSIL.jl")
-include("GD53.jl")
+include("DB.jl")
 include("GD43.jl")
-include("WB.jl")
+include("GD53.jl")
+include("PS.jl")
 include("rCIP.jl")
+include("WB.jl")
+include("XB.jl")
+
+# List of implemented CVIs, useful for iteration
+const CVI_MODULES = [
+    CH,
+    cSIL,
+    DB,
+    GD43,
+    GD53,
+    PS,
+    rCIP,
+    WB,
+    XB,
+]

--- a/src/CVI/CVI.jl
+++ b/src/CVI/CVI.jl
@@ -16,7 +16,17 @@ include("rCIP.jl")
 include("WB.jl")
 include("XB.jl")
 
-# List of implemented CVIs, useful for iteration
+"""
+List of implemented CVIs, useful for iteration.
+Each element is the struct abbreviated name for the CVI, which can be instantiated for iteration with the empty constructor.
+
+For example:
+
+```julia
+using ClusterValidityIndices
+instantiated_cvis = [local_cvi() for local_cvi in CVI_MODULES]
+```
+"""
 const CVI_MODULES = [
     CH,
     cSIL,

--- a/src/ClusterValidityIndices.jl
+++ b/src/ClusterValidityIndices.jl
@@ -107,6 +107,7 @@ export
 
     # CVI utilities
     sort_cvi_data,
-    relabel_cvi_data
+    relabel_cvi_data,
+    CVI_MODULES
 
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -9,6 +9,13 @@ Description:
 # DOCSTRING TEMPLATES
 # --------------------------------------------------------------------------- #
 
+# Default template if not specified (i.e., constants and modules)
+# @template DEFAULT =
+# """
+# $(SIGNATURES)
+# $(DOCSTRING)
+# """
+
 # Types template
 @template TYPES =
 """
@@ -20,9 +27,6 @@ $(DOCSTRING)
 # Fields
 $(TYPEDFIELDS)
 """
-
-# # Constructors
-# $(TYPEDSIGNATURES)
 
 # Template for functions, macros, and methods (i.e., constructors)
 @template (FUNCTIONS, METHODS, MACROS) =

--- a/test/test_cvis.jl
+++ b/test/test_cvis.jl
@@ -50,55 +50,18 @@ A single test set for the testing the functionality of all CVIS modules.
         n_samples[data_path] = length(local_labels)
     end
 
-    # Incremental
-    @info "------- CVI Incremental -------"
-    cvi_i = Dict()
-    for data_path in data_paths
-        @info "Data: $data_path"
-        cvi_i[data_path] = deepcopy(cvis)
-        for cvi in cvi_i[data_path]
-            # @info "ICVI: $(typeof(cvi))"
-            for ix = 1:n_samples[data_path]
-                sample = data[data_path][:, ix]
-                label = labels[data_path][ix]
-                # param_inc!(cvi, data[:, ix], labels[ix])
-                param_inc!(cvi, sample, label)
-                evaluate!(cvi)
-            end
-        end
-    end
-
-    # Batch
-    @info "------- CVI Batch -------"
-    cvi_b = Dict()
-    for data_path in data_paths
-        @info "Data: $data_path"
-        cvi_b[data_path] = deepcopy(cvis)
-        for cvi in cvi_b[data_path]
-            # @info "CVI: $(typeof(cvi))"
-            param_batch!(cvi, data[data_path], labels[data_path])
-            evaluate!(cvi)
-        end
-    end
-
     # Incremental porcelain
     @info "------- ICVI Porcelain -------"
     cvi_ip = Dict()
-    # cvs_ip = Dict()
     for data_path in data_paths
         @info "Data: $data_path"
         cvi_ip[data_path] = deepcopy(cvis)
-        # cvs_ip[data_path] = zeros(n_samples[data_path], n_cvis)
-        # for cx = 1:n_cvis
         for cvi in cvi_ip[data_path]
             for ix = 1:n_samples[data_path]
                 sample = data[data_path][:, ix]
                 label = labels[data_path][ix]
-                # _ = get_icvi!(cvi_ip[data_path][cx], sample, label)
                 _ = get_icvi!(cvi, sample, label)
-                # cvs_ip[data_path][ix, cx] = cv
             end
-            # @info "CVI: $(typeof(cvi)), index: $(@sprintf("%.5f", cvi.criterion_value))"
             @info "CVI: $(typeof(cvi)), index: $(@sprintf("%.12f", cvi.criterion_value))"
         end
     end
@@ -121,26 +84,8 @@ A single test set for the testing the functionality of all CVIS modules.
     # Test that all permutations are equivalent
     for data_path in data_paths
         for cx = 1:n_cvis
-            # I to B
-            @test isapprox(cvi_i[data_path][cx].criterion_value,
-                cvi_b[data_path][cx].criterion_value,
-                atol=tolerance
-            )
-
             # IP to BP
             @test isapprox(cvi_ip[data_path][cx].criterion_value,
-                cvi_bp[data_path][cx].criterion_value,
-                atol=tolerance
-            )
-
-            # I to IP
-            @test isapprox(cvi_i[data_path][cx].criterion_value,
-                cvi_ip[data_path][cx].criterion_value,
-                atol=tolerance
-            )
-
-            # B to BP
-            @test isapprox(cvi_b[data_path][cx].criterion_value,
                 cvi_bp[data_path][cx].criterion_value,
                 atol=tolerance
             )

--- a/test/test_cvis.jl
+++ b/test/test_cvis.jl
@@ -12,18 +12,10 @@ A single test set for the testing the functionality of all CVIS modules.
 Constructs and returns a list of all cvis
 """
 function construct_cvis()
-    # Construct the cvis
-    cvis = [
-        CH(),
-        cSIL(),
-        DB(),
-        GD43(),
-        GD53(),
-        PS(),
-        rCIP(),
-        WB(),
-        XB(),
-    ]
+    # Construct the cvis as a list
+    cvis = [local_cvi() for local_cvi in CVI_MODULES]
+
+    # Return a list of constructed CVIs
     return cvis
 end
 

--- a/test/test_cvis.jl
+++ b/test/test_cvis.jl
@@ -8,12 +8,10 @@ A single test set for the testing the functionality of all CVIS modules.
 - Sasha Petrenko <sap625@mst.edu>
 """
 
-@testset "CVIs" begin
-    @info "CVI Testing"
-
-    # Set the approximation CVI tolerance for all comparisons
-    tolerance = 1e-1
-
+"""
+Constructs and returns a list of all cvis
+"""
+function construct_cvis()
     # Construct the cvis
     cvis = [
         CH(),
@@ -26,7 +24,14 @@ A single test set for the testing the functionality of all CVIS modules.
         WB(),
         XB(),
     ]
-    n_cvis = length(cvis)
+    return cvis
+end
+
+@testset "CVIs" begin
+    @info "CVI Testing"
+
+    # Set the approximation CVI tolerance for all comparisons
+    tolerance = 1e-1
 
     # Grab all the data paths for testing
     data_paths = readdir("../data", join=true)
@@ -55,7 +60,7 @@ A single test set for the testing the functionality of all CVIS modules.
     cvi_ip = Dict()
     for data_path in data_paths
         @info "Data: $data_path"
-        cvi_ip[data_path] = deepcopy(cvis)
+        cvi_ip[data_path] = construct_cvis()
         for cvi in cvi_ip[data_path]
             for ix = 1:n_samples[data_path]
                 sample = data[data_path][:, ix]
@@ -71,19 +76,15 @@ A single test set for the testing the functionality of all CVIS modules.
     cvi_bp = Dict()
     for data_path in data_paths
         @info "Data: $data_path"
-        cvi_bp[data_path] = deepcopy(cvis)
-        # cvs_b = zeros(n_cvis)
-        # for cx = 1:n_cvis
+        cvi_bp[data_path] = construct_cvis()
         for cvi in cvi_bp[data_path]
-            # cvs_b[cx] = get_cvi!(cvi_bp[cx], data, labels)
-            # _ = get_cvi!(cvi_bp[data_path][cx], data[data_path], labels[data_path])
             _ = get_cvi!(cvi, data[data_path], labels[data_path])
         end
     end
 
     # Test that all permutations are equivalent
     for data_path in data_paths
-        for cx = 1:n_cvis
+        for cx in eachindex(cvi_ip[data_path])
             # IP to BP
             @test isapprox(cvi_ip[data_path][cx].criterion_value,
                 cvi_bp[data_path][cx].criterion_value,


### PR DESCRIPTION
This PR significantly speeds up testing while maintaining coverage by removing functionally duplicate tests. Additional convenience types are added for the tests and exported with the project.