### PR TITLE
rCIP edge case test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 DocStringExtensions = "0.8, 0.9"
 NumericalTypeAliases = "0.1"
 ProgressBars = "0.7, 0.8, 1"
-Revise = "3"
 julia = "1"
 
 [extras]

--- a/test/test_cvis.jl
+++ b/test/test_cvis.jl
@@ -85,3 +85,13 @@ end
         end
     end
 end
+
+@testset "Edge Cases" begin
+    @info "Testing CVI Edge Cases"
+
+    # Test rCIP provided a single sample of any one cluster in batch update
+    local_cvi = rCIP()
+    local_data = [1 2 3; 4 5 6] / 2
+    local_labels = [1, 1, 2]
+    _ = get_cvi!(local_cvi, local_data, local_labels)
+end


### PR DESCRIPTION
This PR increases coverage by testing an edge case where rCIP can be updated in batch with only a single sample in any one cluster.